### PR TITLE
Change export default to module.exports

### DIFF
--- a/src/dist/createHashSource.js
+++ b/src/dist/createHashSource.js
@@ -43,4 +43,4 @@ var createHashSource = function () {
         },
     };
 };
-export default createHashSource;
+module.exports = createHashSource;


### PR DESCRIPTION
Prevents this error when importing as an npm module.
```
hash-source/src/dist/createHashSource.js:49
    export default createHashSource;
    ^^^^^^

    SyntaxError: Unexpected token export
```