### PR TITLE
explanation about why global navigate won't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,95 @@ const App = () => {
   )
 }
 ```
+
+## navigate programmatically
+When you need to navigate programmatically (after a form submit for instance), *do not import* `navigate` from reach-router (it will break the hash behaviour), but rather use `props.navigate`at a route component level:
+```
+import { createHistory, Link, LocationProvider, Router } from "@reach/router";
+import React from "react";
+import ReactDOM from "react-dom";
+import createHashSource from "hash-source";
+
+const Home = () => <div>Home</div>;
+const About = () => <div>About</div>;
+const Contact = (
+  { navigate } // navigate is accessible here because Contact is a SubComponent of Router, in the VDom
+) => (
+  <div>
+    <div>Contact</div>
+    <button onClick={() => navigate("/about")}>
+      programmatically navigate to about
+    </button>
+  </div>
+);
+
+const source = createHashSource();
+const history = createHistory(source);
+
+function App() {
+  return (
+    <LocationProvider history={history}>
+      <header>
+        <nav>
+          <Link to="/">Home</Link>
+          <Link to="about">About</Link>
+          <Link to="contact">Contact</Link>
+        </nav>
+      </header>
+
+      <hr />
+
+      <Router>
+        <Home path="/" />
+        <About path="about" />
+        <Contact path="contact" />
+      </Router>
+    </LocationProvider>
+  );
+}
+
+const rootElement = document.getElementById("root");
+ReactDOM.render(<App />, rootElement);
+```
+
+or use `<Loocation>` and its Children as a function pattern:
+```
+import React from "react";
+import { Location } from "@reach/router";
+
+// to prevent `navigate` prop drilling, we can also use the Location component
+const NonRoutedComponent = () => (
+  <Location>
+    {({ navigate }) => (
+      <button onClick={() => navigate("/")}>Submit then Back home</button>
+    )}
+  </Location>
+);
+
+const SubComponent = () => (
+  <div>
+    <p>This is a sub component.</p>
+    <NonRoutedComponent />
+  </div>
+);
+
+const HugeComponent = () => (
+  <div>
+    <p>
+      Imagine this is a big component with a bunch of subcomponents. You may not
+      want to pass drill `navigate` till the very last component requiring it.
+    </p>
+    <SubComponent />
+  </div>
+);
+
+export default HugeComponent;
+```
+
+## Demo
+https://codesandbox.io/s/reach-router-hash-source-npzq8
+
+## Why reach-router global navigate would not work ?
+When using global navigate (`import { navigate } from "@reach/router";`), it will remove the hash behaviour, then not navigate at all.
+
+See `Huge component` in the demo.


### PR DESCRIPTION
I added a few lines about navigating programmatically, and explanation why not to use global navigate from reach-router but rather use either and its Children as a Function pattern, or props.navigate at a route component level.